### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/podium-lib/semantic-release-config.git"
+    "url": "git+https://github.com/podium-lib/semantic-release-config.git"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Updates the package metadata to use the public HTTPS GitHub URL for this repository instead of the SSH-only form.

## Why

The package is public, and the HTTPS repository URL works for users and tooling that do not have SSH access configured for GitHub.

## Validation

- `npm pkg get repository.url`
- Confirmed the diff only changes `repository.url` in `package.json`.
